### PR TITLE
Suggest a more secure way to store the Todoist API key in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ For integration with vim-clap (fuzzy finder) [see below](#integration-with-clap)
 
 Find your API key here: https://todoist.com/prefs/integrations
 
-Export it in your `~/.config/environment.d/*.conf`/`~/.profile`/`~/.bashrc`:
+For security reasons, it is recommended to use [pass](https://www.passwordstore.org/) to store it:
+
 ```bash
-export TODOIST_API_KEY=xxxxxxxx
+$ pass insert Todoist/API
+Enter password for Todoist/API: XXXXXXXXX
+```
+
+Export it in your `~/.config/environment.d/*.conf`/`~/.profile`/`~/.bashrc`
+
+```bash
+export TODOIST_API_KEY="$(pass Todoist/API)"
 ```
 
 ```vim


### PR DESCRIPTION
It's considered bad practice to store your todoist API key out in the
open. You could accidentally share your bashrc and give someone control
to your Todoist account. Pass is a software which encrypts password and
make them easily accessible. This way, your API key is never stored out
in the open and your key is as easily accessible to the plugin.

 On branch master
 Your branch is up to date with 'origin/master'.

 Changes to be committed:
	modified:   README.md
