### PR TITLE
Mappings for task priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Make sure your nodejs provider works (`:checkhealth` to confirm).
 |`x`|Toggle current task completion|
 |`cc`|Change current task text|
 |`cd`|Change current task date ([date formats](https://get.todoist.help/hc/en-us/articles/205325931-Due-Dates-Times))|
+|`p1`|Make task Priority 1|
+|`p2`|Make task Priority 2|
+|`p3`|Make task Priority 3|
+|`p4`|Make task Priority 4|
 |`DD`|Delete current task|
 |`O`|Add new task before|
 |`o`|Add new task after|

--- a/doc/todoist.txt
+++ b/doc/todoist.txt
@@ -79,6 +79,18 @@ o                       Add new task after the cursor.
                                                 *todoist_r*
 r                       Refresh the Todoist session.
 
+                                               *todoist_p1*
+p1                      Change the current tasks' state to Priority 1.
+
+                                               *todoist_p2*
+p2                      Change the current tasks' state to Priority 2.
+
+                                               *todoist_p3*
+p3                      Change the current tasks' state to Priority 3.
+
+                                               *todoist_p4*
+p4                      Change the current tasks' state to Priority 4.
+
                                               *todoist_pcc*
 pcc                     Change the current projects' color.
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const mappings = [
   'nnoremap <buffer><silent> pDD  :call Todoist__onProjectDelete()<CR>',
   'nnoremap <buffer><silent> pcc  :call Todoist__onProjectChangeColor(todoist#get_color())<CR>',
   'nnoremap <buffer><silent> pcn  :call Todoist__onProjectChangeName()<CR>',
-  'nnoremap <buffer><silent> ppp  :call Todoist__onProjectChangePriority()<CR>',
+  'nnoremap <buffer><silent> ppp  :call Todoist__onChangePriority()<CR>',
 ]
 
 const defaultOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -394,13 +394,13 @@ async function onChangePriority() {
   const index = await getCurrentItemIndex()
   const currentItem = state.items[index]
 
-  const priority = await input('Question', 'Priority: ')
-  if (!priority)
+  const pri = await input('Question', 'Priority: ')
+  if (!pri)
     return
 
   const patch = {
     id: currentItem.id,
-    pri: { integer: priority },
+    pri: { priority: pri },
   }
 
   console.log('change-priority', patch)

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const mappings = [
   'nnoremap <buffer><silent> pDD  :call Todoist__onProjectDelete()<CR>',
   'nnoremap <buffer><silent> pcc  :call Todoist__onProjectChangeColor(todoist#get_color())<CR>',
   'nnoremap <buffer><silent> pcn  :call Todoist__onProjectChangeName()<CR>',
+  'nnoremap <buffer><silent> ppp  :call Todoist__onProjectChangePriority()<CR>',
 ]
 
 const defaultOptions = {
@@ -375,6 +376,34 @@ async function onChangeContent() {
   }
 
   console.log('change-content', patch)
+
+  try {
+    currentItem.loading = true
+    await render.line(nvim, state, index)
+    await todoist.items.update(patch)
+    setErrorMessage()
+  } catch(err) {
+    currentItem.loading = false
+    setErrorMessage(err.message)
+  }
+
+  await refresh()
+}
+
+async function onChangePriority() {
+  const index = await getCurrentItemIndex()
+  const currentItem = state.items[index]
+
+  const priority = await input('Question', 'Priority: ')
+  if (!priority)
+    return
+
+  const patch = {
+    id: currentItem.id,
+    pri: { integer: priority },
+  }
+
+  console.log('change-priority', patch)
 
   try {
     currentItem.loading = true

--- a/src/index.js
+++ b/src/index.js
@@ -394,13 +394,13 @@ async function onChangePriority() {
   const index = await getCurrentItemIndex()
   const currentItem = state.items[index]
 
-  const pri = await input('Question', 'Priority: ')
-  if (!pri)
+  const priority = await input('Question', 'Priority: ', currentItem.priority)
+  if (!priority || priority === currentItem.priority)
     return
 
   const patch = {
     id: currentItem.id,
-    pri: { priority: pri },
+    priority,
   }
 
   console.log('change-priority', patch)

--- a/src/index.js
+++ b/src/index.js
@@ -534,6 +534,7 @@ module.exports = plugin => {
   _function('Todoist__onUnindent',           pcall(onUnindent),           { sync: false })
   _function('Todoist__onChangeContent',      pcall(onChangeContent),      { sync: false })
   _function('Todoist__onChangeDate',         pcall(onChangeDate),         { sync: false })
+  _function('Todoist__onChangePriority',     pcall(onChangePriority),     { sync: false })
   _function('Todoist__onRefresh',            pcall(onRefresh),            { sync: false })
   _function('Todoist__onProjectArchive',     pcall(onProjectArchive),     { sync: false })
   _function('Todoist__onProjectDelete',      pcall(onProjectDelete),      { sync: false })

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,10 @@ const mappings = [
   'nnoremap <buffer><silent> pDD  :call Todoist__onProjectDelete()<CR>',
   'nnoremap <buffer><silent> pcc  :call Todoist__onProjectChangeColor(todoist#get_color())<CR>',
   'nnoremap <buffer><silent> pcn  :call Todoist__onProjectChangeName()<CR>',
-  'nnoremap <buffer><silent> ppp  :call Todoist__onChangePriority()<CR>',
+  'nnoremap <buffer><silent> p4  :call Todoist__onChangePriority(1)<CR>',
+  'nnoremap <buffer><silent> p3  :call Todoist__onChangePriority(2)<CR>',
+  'nnoremap <buffer><silent> p2  :call Todoist__onChangePriority(3)<CR>',
+  'nnoremap <buffer><silent> p1  :call Todoist__onChangePriority(4)<CR>',
 ]
 
 const defaultOptions = {
@@ -390,12 +393,11 @@ async function onChangeContent() {
   await refresh()
 }
 
-async function onChangePriority() {
+async function onChangePriority(priority) {
   const index = await getCurrentItemIndex()
   const currentItem = state.items[index]
 
-  const priority = await input('Question', 'Priority: ', currentItem.priority)
-  if (!priority || priority === currentItem.priority)
+  if (priority === currentItem.priority)
     return
 
   const patch = {


### PR DESCRIPTION
You can use the mapping p1,p2,p3, and p4 to change a tasks' priority; 4 is the
least important and 1 is the most important (as in First priority).

I'll possibly create another pull request soon to add colors that match the
current priority to the checkboxes ("[  ]" for standard users and "" for
Nerdfonts). Right now, the priority changes correctly but you have no way of
seeing the change inside todoist.nvim...
