### PR TITLE
Bump todoist to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "date-fns": "^2.14.0",
     "deepmerge": "^4.2.2",
     "rambda": "^5.4.1",
-    "todoist": "^0.3.0"
+    "todoist": "^1.0.0"
   }
 }


### PR DESCRIPTION
1.0.0 is the first version supporting Sync API v9. Sync API v8 was deprecated on November 5, 2022.

I didn't notice any other incompatibility, but I didn't check thoroughly. Either way, v8 is no more.